### PR TITLE
#166816108 Add pagination to get articles ratings feature

### DIFF
--- a/src/controllers/article.controller.js
+++ b/src/controllers/article.controller.js
@@ -377,7 +377,7 @@ export default {
     let { articleId } = request.params;
     articleId = parseInt(articleId, 10);
 
-    const result = await fetchRatingsService(articleId);
+    const result = await fetchRatingsService(articleId, request, response);
 
     if (result === `Article with id: ${articleId} does not exist`) {
       return Helper.failResponse(response, 404, result);

--- a/src/controllers/article.controller.js
+++ b/src/controllers/article.controller.js
@@ -413,5 +413,15 @@ export default {
       });
     }
     if (result) return Helper.successResponse(response, 200, result);
+
+    if (result.length < 1) {
+      return Helper.successResponse(
+        response,
+        200,
+        'specified article does not have any ratings'
+      );
+    }
+
+    return Helper.successResponse(response, 200, result);
   }
 };

--- a/src/helpers/pagination.js
+++ b/src/helpers/pagination.js
@@ -43,7 +43,7 @@ export const pageMetadata = (page = 1, limit = 10, totalItems, entity = '') => {
           1}&limit=${pageLimit}`
       : null;
   if (page > totalPages) {
-    return 'No articles on this page';
+    return 'No content on this page';
   }
   return {
     totalItems,

--- a/src/routes/v1/article.route.js
+++ b/src/routes/v1/article.route.js
@@ -123,7 +123,11 @@ router
     verifyToken,
     validator('commentLike'),
     checkValidationResult,
-    likeComment
+    likeComment,
+    authorization.verifyToken,
+    validator('fetchRating'),
+    checkValidationResult,
+    articleController.fetchRatings
   );
 
 router.get(

--- a/src/routes/v1/article.route.js
+++ b/src/routes/v1/article.route.js
@@ -102,6 +102,8 @@ router
     verifyToken,
     validator('fetchRating'),
     checkValidationResult,
+    paginationValidator()('pagination'),
+    ValidationResult,
     articleController.fetchRatings
   )
   .post(

--- a/src/tests/controller/article.spec.js
+++ b/src/tests/controller/article.spec.js
@@ -236,33 +236,37 @@ describe('Article API endpoints', () => {
           expect(response.body.data.body).to.equal(
             'this is a description this is a description'
           );
+          done();
+        });
+    });
+
+    it('Should successfully create an article', done => {
+      chai
+        .request(app)
+        .post(`${process.env.API_VERSION}/articles`)
+        .set({ Authorization: `Bearer ${userToken}` })
+        .field('title', 'first article')
+        .field('description', 'this is a description')
+        .field('body', 'this is a description this is a description')
+        .end((error, response) => {
+          expect(response.status).to.equal(201);
+          expect(response).to.be.an('Object');
+          expect(response.body).to.have.property('status');
+          expect(response.body).to.have.property('data');
+          expect(response.body.status).to.equal('success');
+          expect(response.body.data.title).to.equal('first article');
+          expect(response.body.data.description).to.equal(
+            'this is a description'
+          );
+          expect(response.body.data.body).to.equal(
+            'this is a description this is a description'
+          );
           createdArticle = response.body.data;
           done();
         });
     });
 
     it('Should return an error if request is empty', done => {
-      chai
-        .request(app)
-        .post(`${process.env.API_VERSION}/articles`)
-        .send({})
-        .set({ Authorization: `Bearer ${userToken}` })
-        .end((error, response) => {
-          expect(response.status).to.equal(400);
-          expect(response).to.be.an('Object');
-          expect(response.body).to.have.property('status');
-          expect(response.body).to.have.property('data');
-          expect(response.body.status).to.equal('fail');
-          expect(response.body.data[0].msg).to.equal(
-            'Please enter your title for this post'
-          );
-          expect(response.body.data[1].msg).to.equal(
-            'Please enter valid content for this article'
-          );
-          done();
-        });
-    });
-    it('Should return an error if user is not authorized', done => {
       chai
         .request(app)
         .post(`${process.env.API_VERSION}/articles`)

--- a/src/tests/controller/auth.spec.js
+++ b/src/tests/controller/auth.spec.js
@@ -221,7 +221,6 @@ describe('Auth API endpoints', () => {
       expect(response.status).to.have.been.calledWith(500);
     });
   });
-
   describe('POST /users/login', () => {
     it('Should log user in successfully', async () => {
       const user = getUser();

--- a/src/validators/article.validator.js
+++ b/src/validators/article.validator.js
@@ -58,6 +58,7 @@ const ArticleValidator = {
           param('articleId')
             .isNumeric({ gt: 0 })
             .not()
+            .not()
             .matches('[-, +, %]')
             .withMessage(
               'Article ID must be a number and can not be less than 1'

--- a/swagger.json
+++ b/swagger.json
@@ -1148,6 +1148,29 @@
           }
         }
       }
+    },
+    "get": {
+      "tags": ["Articles"],
+      "summary": "Post endpoint to rate an article",
+      "produces": ["application/json"],
+      "consumes": ["application/x-www-form-urlencoded"],
+      "parameters": [
+        {
+          "name": "articleId",
+          "in": "path",
+          "description": "id of the article's ratings to be fetched",
+          "required": true,
+          "type": "integer"
+        }
+      ],
+      "responses": {
+        "400": {
+          "description": "Error in input"
+        },
+        "401": {
+          "description": "Error with authentication"
+        }
+      }
     }
   },
   "securityDefinitions": {


### PR DESCRIPTION
#### What does this PR do?
Implement pagination for getting articles rating feature
#### Description of Task to be completed?
- Add pagination to articles rating feature
- Write unit tests
- Document using swagger
#### How should this be manually tested?
* clone the repo using git clone https://github.com/andela/persephone-ah-backend.git
* on your terminal, run cd persephone-ah-backend
* run npm install
* run npm run start
* make a request to GET localhost:3000/api/v1/articles/articleId/ratings?page=1&limit=10
* change the values of the page and limit queries for different effects
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#166816108](https://www.pivotaltracker.com/n/projects/2353116/stories/166816108)
#### Questions:
None