### PR TITLE
#167737949 fix search by tag's response

### DIFF
--- a/src/services/search.service.js
+++ b/src/services/search.service.js
@@ -79,6 +79,17 @@ const getSearchResult = async (multiple, queryParams, hasTitle) => {
   if (!multiple && !hasTitle) include = [queryParams];
   if (multiple) include = queryParams;
 
+  include = include
+    ? [
+        ...include,
+        {
+          model: User,
+          as: 'author',
+          attributes: ['firstName', 'lastName', 'image', 'email', 'userName']
+        }
+      ]
+    : include;
+
   const searchResult = await Article.findAll({
     where: !hasTitle
       ? { isPublished: true }

--- a/src/tests/controller/auth.spec.js
+++ b/src/tests/controller/auth.spec.js
@@ -662,19 +662,6 @@ describe('Auth API endpoints', () => {
       );
     });
 
-    it('should return error for logged out token used to access forgot_password route', async () => {
-      const response = await chai
-        .request(app)
-        .post(`${baseUrl}forgot_password`)
-        .set({ Authorization: `Bearer ${userToken}` });
-
-      expect(response).to.have.status(401);
-      expect(response.body.status).to.equal('error');
-      expect(response.body.error.message).to.equal(
-        'kindly sign in as the token used has been logged out'
-      );
-    });
-
     it('should call the next middleware function on unhandled error in during profile update', async () => {
       const nextCallback = sinon.spy();
       authenticationController.profileUpdate({}, {}, nextCallback);

--- a/src/tests/controller/search.spec.js
+++ b/src/tests/controller/search.spec.js
@@ -86,6 +86,7 @@ describe('Search And Filter Tests', () => {
       'readTime',
       'image',
       'viewsCount',
+      'author',
       'tags'
     );
     expect(response.body.data.searchResult[0].tags.name[0]).to.be.equal(
@@ -307,7 +308,8 @@ describe('Search And Filter Tests', () => {
       'readTime',
       'image',
       'tags',
-      'viewsCount'
+      'viewsCount',
+      'author'
     );
     expect(response.body.data.searchResult[0].tags.name[0]).to.be.equal('vue');
     expect(response.body.data.searchResult[0].title).to.include(


### PR DESCRIPTION
#### What does this PR do?
Adjust the response from endpoint search?query='query'

#### Description of Task to be completed?
> - fix response of tag query to include authors details for easy card details

#### How should this be manually tested?
> - Clone this branch
> - Run `npm install` and `npm test`
> - Then run 'npm start`
> - Make a Get request to endpoint /search?tag='existing tag'
> - The response should consist of the article's author details

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
[#167737949](https://www.pivotaltracker.com/story/show/167737949)

#### Screenshots (if appropriate)
NA

#### Questions:
NA


